### PR TITLE
Add blague command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Eve is a simple discord bot that can be used for multiple things, including IA f
     DATABASE_URL="mysql_connection_url"
 
     GOOGLE_API_KEY=your_google_api_key
+
+    BLAGUE_API_TOKEN=your_blague_api_token
     ```
 
 4. Run the prisma migrations with `yarn prisma migrate deploy`

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@google/generative-ai": "^0.21.0",
     "@prisma/client": "^5.22.0",
+    "blagues-api": "^2.1.1",
     "cron": "^3.2.1",
     "discord.js": "^14.16.3",
     "dotenv": "^16.0.3",

--- a/src/commands/fun/blague.ts
+++ b/src/commands/fun/blague.ts
@@ -1,0 +1,64 @@
+import { config } from "@/config";
+import BlaguesAPI from "blagues-api";
+import { Category } from "blagues-api/dist/types/types";
+import { ColorResolvable, CommandInteraction, EmbedBuilder, SlashCommandBuilder, SlashCommandOptionsOnlyBuilder } from "discord.js";
+
+const blagues = new BlaguesAPI(config.BLAGUE_API_TOKEN)
+
+export const data: SlashCommandOptionsOnlyBuilder = new SlashCommandBuilder()
+    .setName("blague")
+    .setDescription("Affiche une blague (Eve et ses développeurs ne sont pas responsables des blagues affichées)")
+    .addStringOption(option =>
+        option.setName("type")
+            .setDescription("Le type de blague à afficher")
+            .setRequired(false)
+            .addChoices([
+                {
+                    name: "Générale",
+                    value: blagues.categories.GLOBAL
+                },
+                {
+                    name: "Développeur",
+                    value: blagues.categories.DEV
+                },
+                {
+                    name: "Humour noir",
+                    value: blagues.categories.DARK
+                },
+                {
+                    name: "Limite limite",
+                    value: blagues.categories.LIMIT
+                },
+                {
+                    name: "Beauf",
+                    value: blagues.categories.BEAUF
+                },
+                {
+                    name: "Blondes",
+                    value: blagues.categories.BLONDES
+                }
+            ])
+    );
+
+function randomEmbedColor(): ColorResolvable {
+    return Math.floor(Math.random() * 16777215)
+}
+
+export async function execute(interaction: CommandInteraction): Promise<void> {
+    await interaction.deferReply()
+    const type = interaction.options.get("type")?.value as Category
+    const joke = await blagues.randomCategorized(type)
+
+    const embed = new EmbedBuilder()
+        .setTitle("Blague")
+        .setDescription(joke.joke)
+        .addFields({
+            name: "Réponse",
+            value: joke.answer
+        })
+        .setColor(randomEmbedColor())
+        .setFooter({ text: `Eve – Toujours prête à vous aider. (Eve et ses développeurs ne sont pas responsables des blagues affichées)`, iconURL: interaction.client.user?.displayAvatarURL() })
+        .setTimestamp()
+
+    await interaction.editReply({ embeds: [embed] })
+}

--- a/src/commands/fun/blague.ts
+++ b/src/commands/fun/blague.ts
@@ -57,7 +57,7 @@ export async function execute(interaction: CommandInteraction): Promise<void> {
             value: joke.answer
         })
         .setColor(randomEmbedColor())
-        .setFooter({ text: `Eve – Toujours prête à vous aider. (Eve et ses développeurs ne sont pas responsables des blagues affichées)`, iconURL: interaction.client.user?.displayAvatarURL() })
+        .setFooter({ text: `Eve et ses développeurs ne sont pas responsables des blagues affichées.`, iconURL: interaction.client.user?.displayAvatarURL() })
         .setTimestamp()
 
     await interaction.editReply({ embeds: [embed] })

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,6 +10,7 @@ import * as rename from "./config/rename"
 
 import * as cat from "./fun/cat"
 import * as dog from "./fun/dog"
+import * as blague from "./fun/blague"
 
 import * as quiz from "./fun/quiz/quiz"
 import * as addquestion from "./fun/quiz/addquestion"
@@ -50,6 +51,7 @@ export const commands = {
     quizstats,
     leaderboard,
     chaban,
+    blague,
 
     // Calendar commands
     createcalendar,

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,9 +2,9 @@ import dotenv from "dotenv"
 
 dotenv.config()
 
-const { DISCORD_TOKEN, DISCORD_CLIENT_ID, EVE_HOME_GUILD, OWNER_ID, LOGS_WEBHOOK_URL, GOOGLE_API_KEY, REPORT_CHANNEL, MP_CHANNEL } = process.env
+const { DISCORD_TOKEN, DISCORD_CLIENT_ID, EVE_HOME_GUILD, OWNER_ID, LOGS_WEBHOOK_URL, GOOGLE_API_KEY, REPORT_CHANNEL, MP_CHANNEL, BLAGUE_API_TOKEN } = process.env
 
-if (!DISCORD_TOKEN || !DISCORD_CLIENT_ID || !EVE_HOME_GUILD || !OWNER_ID || !LOGS_WEBHOOK_URL || !REPORT_CHANNEL || !MP_CHANNEL) {
+if (!DISCORD_TOKEN || !DISCORD_CLIENT_ID || !EVE_HOME_GUILD || !OWNER_ID || !LOGS_WEBHOOK_URL || !REPORT_CHANNEL || !MP_CHANNEL || !BLAGUE_API_TOKEN) {
     throw new Error("Missing environment variables")
 }
 
@@ -19,6 +19,7 @@ if (!DISCORD_TOKEN || !DISCORD_CLIENT_ID || !EVE_HOME_GUILD || !OWNER_ID || !LOG
  * @property {string} GOOGLE_API_KEY - The API key used to authenticate with Google services.
  * @property {string} REPORT_CHANNEL - The ID of the channel where reports are sent.
  * @property {string} MP_CHANNEL - The ID of the channel where MPs are sent.
+ * @property {string} BLAGUE_API_TOKEN - The token used to authenticate with the Blague API.
  */
 export const config = {
     DISCORD_TOKEN,
@@ -28,5 +29,6 @@ export const config = {
     LOGS_WEBHOOK_URL,
     GOOGLE_API_KEY,
     REPORT_CHANNEL,
-    MP_CHANNEL
+    MP_CHANNEL,
+    BLAGUE_API_TOKEN
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { initCalendars, updateCalendars } from "./commands/calendar/createcalend
 export const logger = new Logger()
 logger.initLevels()
 
+
 export const client = new Client({
     intents: [
         GatewayIntentBits.Guilds,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
         "paths": {
             "@/*": ["./src/*"]
         }
-    }
+    },
+    "exclude": ["dist", "node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1187,6 +1187,13 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+blagues-api@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/blagues-api/-/blagues-api-2.1.1.tgz#35b23c1217e389b59b09e6d0a2823902ea3d8562"
+  integrity sha512-Wjyvgh/Ke/RHBNLBNbvsHPjEXfeHZEEee++M8+f2YL5GeNty2kvlAGkhGdmPqdWmUYhvtOr9G3MdKF5NoYwW7w==
+  dependencies:
+    cross-fetch "^3.1.5"
+
 bmp-js@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/bmp-js/-/bmp-js-0.1.0.tgz#e05a63f796a6c1ff25f4771ec7adadc148c07233"
@@ -1318,6 +1325,13 @@ cron@^3.2.1:
   dependencies:
     "@types/luxon" "~3.4.0"
     luxon "~3.5.0"
+
+cross-fetch@^3.1.5:
+  version "3.1.8"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
+  integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==
+  dependencies:
+    node-fetch "^2.6.12"
 
 cross-spawn@^7.0.0:
   version "7.0.3"
@@ -2541,7 +2555,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-node-fetch@^2.6.1:
+node-fetch@^2.6.1, node-fetch@^2.6.12:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
   integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==


### PR DESCRIPTION
This pull request introduces a new feature to the discord bot by adding support for fetching and displaying jokes using the Blague API. The most important changes include updating the configuration to include the Blague API token, adding a new command for jokes, and updating dependencies.

### New Feature: Blague API Integration

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R65-R66): Added instructions to include `BLAGUE_API_TOKEN` in the environment variables.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R21): Added `blagues-api` as a new dependency.

### Command Implementation

* [`src/commands/fun/blague.ts`](diffhunk://#diff-c2ddf5961b15ac9d63596d92d58df22a74743176c4bb1fcabead4b278db000e1R1-R64): Created a new command file to fetch and display jokes from the Blague API.

### Configuration Updates

* [`src/config.ts`](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L5-R7): Updated configuration to include `BLAGUE_API_TOKEN` and added validation to ensure it is provided. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L5-R7) [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R22) [[3]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L31-R33)

### Command Registration

* [`src/commands/index.ts`](diffhunk://#diff-a6a1db61476382a80351bf0b40126b3cfca87878293a3fca70dfe04367f4a11fR13): Registered the new `blague` command in the command index. [[1]](diffhunk://#diff-a6a1db61476382a80351bf0b40126b3cfca87878293a3fca70dfe04367f4a11fR13) [[2]](diffhunk://#diff-a6a1db61476382a80351bf0b40126b3cfca87878293a3fca70dfe04367f4a11fR54)