### PR TITLE
Remove commented-out categories from blague command options

### DIFF
--- a/src/commands/fun/blague.ts
+++ b/src/commands/fun/blague.ts
@@ -21,10 +21,10 @@ export const data: SlashCommandOptionsOnlyBuilder = new SlashCommandBuilder()
                     name: "Développeur",
                     value: blagues.categories.DEV
                 },
-                {
+                /* {
                     name: "Humour noir",
                     value: blagues.categories.DARK
-                },
+                }, */
                 {
                     name: "Limite limite",
                     value: blagues.categories.LIMIT
@@ -33,10 +33,10 @@ export const data: SlashCommandOptionsOnlyBuilder = new SlashCommandBuilder()
                     name: "Beauf",
                     value: blagues.categories.BEAUF
                 },
-                {
+                /* {
                     name: "Blondes",
                     value: blagues.categories.BLONDES
-                }
+                } */
             ])
     );
 


### PR DESCRIPTION
This pull request includes changes to the `src/commands/fun/blague.ts` file to comment out certain joke categories. The most important changes include commenting out the "Humour noir" and "Blondes" joke categories.

Changes to joke categories:

* [`src/commands/fun/blague.ts`](diffhunk://#diff-c2ddf5961b15ac9d63596d92d58df22a74743176c4bb1fcabead4b278db000e1L24-R27): Commented out the "Humour noir" joke category.
* [`src/commands/fun/blague.ts`](diffhunk://#diff-c2ddf5961b15ac9d63596d92d58df22a74743176c4bb1fcabead4b278db000e1L36-R39): Commented out the "Blondes" joke category.