### PR TITLE
feat: add leaderboard subcommand to quiz with sorting options

### DIFF
--- a/bot/commands/handlers/fun/quiz.ts
+++ b/bot/commands/handlers/fun/quiz.ts
@@ -312,18 +312,26 @@ export const quiz: ICommand = {
                     .setTitle('Classement des joueurs de quiz')
                     .setDescription(`Voici le classement des joueurs de quiz pour ${stringChoice} :`)
                     .setColor(0x4b0082);
-                users.forEach(async (user, index) => {
-                    const userId = user.userId;
-                    const userTag = await client.users.fetch(userId).then((user) => user.tag).catch(() => 'Utilisateur inconnu');
-                    if (!userTag) {
-                        return;
+                const leaderboardFields = await Promise.all(
+                    users.map(async (user, index) => {
+                        const userId = user.userId;
+                        const userTag = await client.users.fetch(userId).then((user) => user.tag).catch(() => 'Utilisateur inconnu');
+                        if (!userTag) {
+                            return null;
+                        }
+                        const ratio = user.quizGoodAnswers / (user.quizGoodAnswers + user.quizBadAnswers) || 0;
+                        return {
+                            name: `${index + 1}. ${userTag}`,
+                            value: `Score : ${user.quizGoodAnswers} | Mauvais : ${user.quizBadAnswers} | Ratio : ${ratio.toFixed(2)}`,
+                            inline: false,
+                        };
+                    })
+                );
+
+                leaderboardFields.forEach((field) => {
+                    if (field) {
+                        leaderboardEmbed.addFields(field);
                     }
-                    const ratio = user.quizGoodAnswers / (user.quizGoodAnswers + user.quizBadAnswers) || 0;
-                    leaderboardEmbed.addFields({
-                        name: `${index + 1}. ${userTag}`,
-                        value: `Score : ${user.quizGoodAnswers} | Mauvais : ${user.quizBadAnswers} | Ratio : ${ratio.toFixed(2)}`,
-                        inline: false,
-                    });
                 });
 
                 await interaction.editReply({

--- a/bot/commands/handlers/fun/quiz.ts
+++ b/bot/commands/handlers/fun/quiz.ts
@@ -312,27 +312,21 @@ export const quiz: ICommand = {
                     .setTitle('Classement des joueurs de quiz')
                     .setDescription(`Voici le classement des joueurs de quiz pour ${stringChoice} :`)
                     .setColor(0x4b0082);
-                const leaderboardFields = await Promise.all(
-                    users.map(async (user, index) => {
-                        const userId = user.userId;
-                        const userTag = await client.users.fetch(userId).then((user) => user.tag).catch(() => 'Utilisateur inconnu');
-                        if (!userTag) {
-                            return null;
-                        }
-                        const ratio = user.quizGoodAnswers / (user.quizGoodAnswers + user.quizBadAnswers) || 0;
-                        return {
-                            name: `${index + 1}. ${userTag}`,
-                            value: `Score : ${user.quizGoodAnswers} | Mauvais : ${user.quizBadAnswers} | Ratio : ${ratio.toFixed(2)}`,
-                            inline: false,
-                        };
-                    })
-                );
 
-                leaderboardFields.forEach((field) => {
-                    if (field) {
-                        leaderboardEmbed.addFields(field);
+                // Fetch user tags and add fields before sending the embed
+                await Promise.all(users.map(async (user, index) => {
+                    const userId = user.userId;
+                    const userTag = await client.users.fetch(userId).then((user) => user.tag).catch(() => 'Utilisateur inconnu');
+                    if (!userTag) {
+                        return;
                     }
-                });
+                    const ratio = user.quizGoodAnswers / (user.quizGoodAnswers + user.quizBadAnswers) || 0;
+                    leaderboardEmbed.addFields({
+                        name: `${index + 1}. ${userTag}`,
+                        value: `Score : ${user.quizGoodAnswers} | Mauvais : ${user.quizBadAnswers} | Ratio : ${ratio.toFixed(2)}`,
+                        inline: false,
+                    });
+                }));
 
                 await interaction.editReply({
                     embeds: [leaderboardEmbed],

--- a/bot/commands/handlers/fun/quiz.ts
+++ b/bot/commands/handlers/fun/quiz.ts
@@ -86,7 +86,7 @@ export const quiz: ICommand = {
                                 value: 'best_ratios',
                             },
                             {
-                                name: 'Pires scores',
+                                name: 'Scores les plus bas',
                                 value: 'worst_scores',
                             }
                         )

--- a/bot/commands/handlers/fun/quiz.ts
+++ b/bot/commands/handlers/fun/quiz.ts
@@ -317,9 +317,6 @@ export const quiz: ICommand = {
                 await Promise.all(users.map(async (user, index) => {
                     const userId = user.userId;
                     const userTag = await client.users.fetch(userId).then((user) => user.tag).catch(() => 'Utilisateur inconnu');
-                    if (!userTag) {
-                        return;
-                    }
                     const ratio = user.quizGoodAnswers / (user.quizGoodAnswers + user.quizBadAnswers) || 0;
                     leaderboardEmbed.addFields({
                         name: `${index + 1}. ${userTag}`,

--- a/utils/rp/lsms.ts
+++ b/utils/rp/lsms.ts
@@ -150,6 +150,8 @@ export async function prepareLsmsSummary() {
                         logger.error(`Le channel de logs LSMS n'est pas valide dans le serveur ${dutyManager.guildId}`);
                     }
                 }
+            } else {
+                logger.warn(`Aucune donnée de service trouvée pour le serveur ${dutyManager.guildId}`);
             }
         });
     });


### PR DESCRIPTION
This pull request enhances the `quiz` command in `bot/commands/handlers/fun/quiz.ts` by adding a new subcommand for displaying quiz leaderboards and introducing functionality to fetch and sort user data based on different criteria. Additionally, it includes a minor import adjustment to support the new functionality.

### New Feature: Quiz Leaderboards

* Added a `leaderboard` subcommand to the `quiz` command, allowing users to view quiz rankings based on three criteria: best scores, best ratios, and worst scores. Each option sorts and filters user data accordingly, displaying the top 10 players in an embed. [[1]](diffhunk://#diff-9305d1a13744aee08d87726e34eb664557c8aae3613ff8017e4857b6f5ed4d42R70-R94) [[2]](diffhunk://#diff-9305d1a13744aee08d87726e34eb664557c8aae3613ff8017e4857b6f5ed4d42R270-R336)

### Code Adjustments

* Imported the `client` object to fetch user tags for the leaderboard display. This ensures proper identification of users in the rankings.